### PR TITLE
Change references of "Face" to "Index" in G1M Submesh

### DIFF
--- a/Model related formats/G1M/G1MG/G1MG_SubMesh.bt
+++ b/Model related formats/G1M/G1MG/G1MG_SubMesh.bt
@@ -34,8 +34,8 @@ typedef struct G1MGEOMETRYSUBMESH {
     G1MGeometrySubMeshFaceType face_type<name="Face Type">;
     int vertex_offset<name="Vertex Offset">;
     int vertex_count<name="Vertex Count">;
-    int face_offset<name="Face Offset">;
-    int face_count<name="Face Count">;
+    int face_offset<name="Index Offset">;
+    int face_count<name="Index Count">;
 } G1MGeometrySubMesh;
 
 #endif // G1M_GEOMETRY_SUBMESH


### PR DESCRIPTION
The G1M Submesh section uses the Face Type to determine how to traverse the index buffer, therefore it is not accurate to describe the info following "Vertex Offset" and "Vertex Count" with the term "Face" since not every mesh will use the same kind of face type and it actually refers to the indices anyways.

I found out about this discrepancy when comparing what the template and Noesis were saying about how many faces a certain submesh has and noticing that the template was declaring a value 3 times as large than what Noesis had(which makes sense since that submesh was triangulated).